### PR TITLE
using TopologyRecoveryRetryHandler to workaround the problem

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-api:2.18.0"
     implementation "org.apache.logging.log4j:log4j-core:2.18.0"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.18.0"
+    implementation "io.github.resilience4j:resilience4j-retry:1.7.1"
 }
 
 application {

--- a/app/src/main/java/com/example/rabbitautorecoveryreproductor/AmqpConnectionFactory.java
+++ b/app/src/main/java/com/example/rabbitautorecoveryreproductor/AmqpConnectionFactory.java
@@ -3,13 +3,17 @@ package com.example.rabbitautorecoveryreproductor;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.base.Splitter;
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.impl.recovery.RecordedEntity;
 import com.rabbitmq.client.impl.recovery.RetryHandler;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryHandlerBuilder;
 import com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic;
@@ -21,6 +25,24 @@ public class AmqpConnectionFactory {
     private static final Logger log = LogManager.getLogger();
     protected static final int TOPOLOGY_RECOVER_RETRY_INITIAL_DELAY_MS = 5000;
     protected static final int TOPOLOGY_RECOVER_RETRY_ATTEMPTS = 5;
+
+    /**
+     * The original predicate from TopologyRecoveryRetryLogic.CHANNEL_CLOSED_NOT_FOUND is working ok for version 5.15.0
+     * but on older versions (5.7.3 or 4.12.0) it returns false, because exception intercepted by the handler
+     * is not wrapped in additional IOException.
+     *
+     * This predicate accepts this alternative scenario.
+     */
+    private static final BiPredicate<RecordedEntity, Exception> CHANNEL_CLOSED_NOT_FOUND_WITHOUT_IOEXCEPTION = (entity, ex) -> {
+        if (ex instanceof ShutdownSignalException) {
+            ShutdownSignalException cause = (ShutdownSignalException) ex;
+            if (cause.getReason() instanceof AMQP.Channel.Close) {
+                return ((AMQP.Channel.Close) cause.getReason()).getReplyCode() == 404;
+            }
+        }
+        return false;
+    };
+
     private final String username;
     private final String password;
     private final List<Address> hosts;
@@ -60,6 +82,8 @@ public class AmqpConnectionFactory {
 
     private RetryHandler buildTopologyRecoveryRetryHandler(long initialDelayMs, int retryAttempts) {
         final TopologyRecoveryRetryHandlerBuilder builder = TopologyRecoveryRetryLogic.RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER;
+        builder.bindingRecoveryRetryCondition(TopologyRecoveryRetryLogic.CHANNEL_CLOSED_NOT_FOUND.or(CHANNEL_CLOSED_NOT_FOUND_WITHOUT_IOEXCEPTION));
+        builder.consumerRecoveryRetryCondition(TopologyRecoveryRetryLogic.CHANNEL_CLOSED_NOT_FOUND.or(CHANNEL_CLOSED_NOT_FOUND_WITHOUT_IOEXCEPTION));
         builder.backoffPolicy(new ExpBackoffPolicy(initialDelayMs, 2));
         builder.retryAttempts(retryAttempts);
         return builder.build();

--- a/app/src/main/java/com/example/rabbitautorecoveryreproductor/AmqpConnectionFactory.java
+++ b/app/src/main/java/com/example/rabbitautorecoveryreproductor/AmqpConnectionFactory.java
@@ -10,12 +10,17 @@ import com.google.common.base.Splitter;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.impl.recovery.RetryHandler;
+import com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryHandlerBuilder;
+import com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class AmqpConnectionFactory {
 
     private static final Logger log = LogManager.getLogger();
+    protected static final int TOPOLOGY_RECOVER_RETRY_INITIAL_DELAY_MS = 5000;
+    protected static final int TOPOLOGY_RECOVER_RETRY_ATTEMPTS = 5;
     private final String username;
     private final String password;
     private final List<Address> hosts;
@@ -30,12 +35,12 @@ public class AmqpConnectionFactory {
             log.debug("adding address host={}, port={}", host, port);
             return new Address(host, port);
         }).collect(Collectors.toList());
-
     }
 
     public Connection createNewConnection() throws RabbitMQConnectionException {
         try {
             ConnectionFactory factory = new ConnectionFactory();
+            factory.setTopologyRecoveryRetryHandler(buildTopologyRecoveryRetryHandler(TOPOLOGY_RECOVER_RETRY_INITIAL_DELAY_MS, TOPOLOGY_RECOVER_RETRY_ATTEMPTS));
             factory.setThreadFactory(new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable r) {
@@ -52,4 +57,12 @@ public class AmqpConnectionFactory {
             throw new RabbitMQConnectionException("Failed to start AMQP connection", e);
         }
     }
+
+    private RetryHandler buildTopologyRecoveryRetryHandler(long initialDelayMs, int retryAttempts) {
+        final TopologyRecoveryRetryHandlerBuilder builder = TopologyRecoveryRetryLogic.RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER;
+        builder.backoffPolicy(new ExpBackoffPolicy(initialDelayMs, 2));
+        builder.retryAttempts(retryAttempts);
+        return builder.build();
+    }
+
 }

--- a/app/src/main/java/com/example/rabbitautorecoveryreproductor/ExpBackoffPolicy.java
+++ b/app/src/main/java/com/example/rabbitautorecoveryreproductor/ExpBackoffPolicy.java
@@ -1,0 +1,43 @@
+package com.example.rabbitautorecoveryreproductor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.rabbitmq.client.impl.recovery.BackoffPolicy;
+
+import io.github.resilience4j.core.IntervalFunction;
+
+public class ExpBackoffPolicy implements BackoffPolicy {
+
+    private static final Logger log = LogManager.getLogger();
+
+    private final long initialIntervalMs;
+    private final int multiplier;
+
+    ExpBackoffPolicy(long initialDelayMs, int multiplier) {
+        this.initialIntervalMs = initialDelayMs;
+        this.multiplier = multiplier;
+    }
+
+    @Override
+    public void backoff(int attemptNumber) throws InterruptedException {
+        long sleepTimeMs = getSleepTimeMs(attemptNumber);
+
+        log.debug("Backoff attempt {}, will sleep {} ms", attemptNumber, sleepTimeMs);
+        Thread.sleep((long) sleepTimeMs);
+    }
+
+    public long getSleepTimeMs(int attemptNumber) {
+        IntervalFunction intervalFunction = IntervalFunction.ofExponentialBackoff(initialIntervalMs, multiplier);
+        long sleepTimeMs = intervalFunction.apply(attemptNumber);
+
+        // logX(Y) = log10(Y) / log10(X), so basically we calculate here log with base=multiplier of Long.MAX_VALUE
+        //        double maxAttemptNr = (Math.log10(Long.MAX_VALUE) / Math.log10(multiplier)) - 1;
+        //        int effectiveAttemptNr = attemptNumber;
+        //        if (attemptNumber > maxAttemptNr) {
+        //            effectiveAttemptNr = (int) Math.floor(maxAttemptNr);
+        //        }
+        //        long sleepTimeMs = (long) (initialIntervalMs * Math.pow(multiplier, effectiveAttemptNr-1));
+        return sleepTimeMs;
+    }
+}

--- a/app/src/test/java/com/example/rabbitautorecoveryreproductor/ExpBackoffPolicyTest.java
+++ b/app/src/test/java/com/example/rabbitautorecoveryreproductor/ExpBackoffPolicyTest.java
@@ -1,0 +1,17 @@
+package com.example.rabbitautorecoveryreproductor;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ExpBackoffPolicyTest {
+
+    @Test
+    void testBackoff() {
+
+        ExpBackoffPolicy b = new ExpBackoffPolicy(2000, 2);
+        Assertions.assertEquals(2000L, b.getSleepTimeMs(1));
+        Assertions.assertEquals(4000L, b.getSleepTimeMs(2));
+        Assertions.assertEquals(8000L, b.getSleepTimeMs(3));
+    }
+
+}


### PR DESCRIPTION
Found this useful piece of code https://github.com/rabbitmq/rabbitmq-java-client/issues/387
It seems that retrying the topology recovery successfully works around the problem!